### PR TITLE
Update run_re.py

### DIFF
--- a/relation-extraction/run_re.py
+++ b/relation-extraction/run_re.py
@@ -141,7 +141,8 @@ def main():
     # download model & vocab.
     
     # Currently, this code do not support distributed training.
-    training_args.warmup_steps = int(model_args.warmup_proportion * (len(train_dataset) / training_args.per_device_train_batch_size) * training_args.num_train_epochs)
+    if training_args.do_train:
+        training_args.warmup_steps = int(model_args.warmup_proportion * (len(train_dataset) / training_args.per_device_train_batch_size) * training_args.num_train_epochs)
     training_args_weight_decay = 0.01
     logger.info("Training/evaluation parameters %s", training_args)
     


### PR DESCRIPTION
fix error for only making prediction purpose without arg "--do_train" was given :
"Traceback (most recent call last):
  File "run_re.py", line 259, in <module>
    main()
  File "run_re.py", line 145, in main
    training_args.warmup_steps = int(model_args.warmup_proportion * (len(train_dataset) / training_args.per_device_train_batch_size) * training_args.num_train_epochs)
TypeError: object of type 'NoneType' has no len()"