### PR TITLE
Fix wrong answer filename while evaluating RE

### DIFF
--- a/relation-extraction/README.md
+++ b/relation-extraction/README.md
@@ -40,7 +40,7 @@ python run_re.py \
 
 ## Evaluation
 ```bash
-python ./scripts/re_eval.py --output_path=${SAVE_DIR}/${ENTITY}/test_results.txt --answer_path=${DATA_DIR}/test_original.tsv
+python ./scripts/re_eval.py --output_path=${SAVE_DIR}/${ENTITY}/test_results.txt --answer_path=${DATA_DIR}/test.tsv
 ```
 To evaluate the prediction, please use `scripts/re_eval.py` file. 
 For an example running script for 10-cv experiment, please task a look at `run_re_10cv.sh` and `scripts/re_eval_10cv.sh`.

--- a/relation-extraction/scripts/re_eval_10cv.sh
+++ b/relation-extraction/scripts/re_eval_10cv.sh
@@ -7,5 +7,5 @@ do
   echo "***** " $DATA " test score " $SPLIT " *****"
   python scripts/re_eval.py \
     --output_path=./output/$ENTITY/test_results.txt \
-    --answer_path=../datasets/RE/$DATA/$SPLIT/test_original.tsv
+    --answer_path=../datasets/RE/$DATA/$SPLIT/test.tsv
 done


### PR DESCRIPTION
Hi,  

I found that the filename of original answer seems wrong. After downloading datasets by `./download.sh`, there is only `test.tsv` in `RE/<ENTITY>/<SPLIT>` instead of `test_original.tsv`.

Thank you 