### PR TITLE
fix NER preprocessing

### DIFF
--- a/named-entity-recognition/scripts/preprocess.py
+++ b/named-entity-recognition/scripts/preprocess.py
@@ -1,4 +1,7 @@
 import sys
+import os
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 from transformers import AutoTokenizer
 


### PR DESCRIPTION
When processing, parallelism output warning messages. Then these messages is included *.txt files. So it seems like to need to set ```TOKENIZERS_PARALLELISM==False```.